### PR TITLE
Fix test suite on node v6

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -108,7 +108,7 @@ describe('Netki Partner Client Tests', function () {
 
       netki._processRequest(partner_id, api_key, uri, 'GET')
         .fail(function (error) {
-          expect(error).to.equal('Error Parsing JSON Data: SyntaxError: Unexpected token o')
+          expect(error).to.match(/^Error Parsing JSON Data: SyntaxError: Unexpected token o/)
         })
         .done(function () {
           done()


### PR DESCRIPTION
Starting with Node v6, the error thrown when parsing a JSON fails contain the position of the token that generated the error. The test that validates parsing errors is correct must be flexible enough to accept both errors, with and without position index.